### PR TITLE
sourcepkg: add a complete source package build

### DIFF
--- a/.github/workflows/sourcepkg.yml
+++ b/.github/workflows/sourcepkg.yml
@@ -1,0 +1,25 @@
+name: Source Package
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: "go.mod"
+
+    - name: Run build & test
+      run: |
+        cd sourcepkg
+        make check

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 libtailscale.so
 libtailscale.a
 libtailscale.h
+libtailscale.tar*
 /ruby/tmp/
 /ruby/pkg/
 /ruby/doc/
@@ -8,3 +9,6 @@ libtailscale.h
 /ruby/ext/libtailscale/go.mod
 /ruby/ext/libtailscale/go.sum
 /ruby/LICENSE
+/sourcepkg/libtailscale
+/sourcepkg/libtailscale.tar*
+/vendor/

--- a/sourcepkg/Makefile
+++ b/sourcepkg/Makefile
@@ -1,0 +1,31 @@
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Construct a source package by vendoring all source and packing it up into a
+# tarball.
+
+ifeq ($(shell uname -s),Darwin)
+	TAR?=gtar
+else
+	TAR?=tar
+endif
+
+all: check
+
+check: libtailscale.tar.zst
+	@echo "Checking that the tarball is self-contained..."
+	test `$(TAR) tf libtailscale.tar.zst | grep -c -v '^libtailscale/'` -eq 0 || (echo "Tarball is not self-contained!" && exit 1)
+
+	@tar xf libtailscale.tar.zst
+	@echo "Checking that the tarball is usable..."
+	@cd libtailscale && ./configure && make
+
+
+clean:
+	rm -rf ./libtailscale.tar.zst ../vendor ./libtailscale
+
+../vendor: ../go.mod ../go.sum ../tailscale.go Makefile.src Makefile
+	go mod vendor
+
+libtailscale.tar.zst: Makefile.src configure ../vendor ../LICENSE ../tailscale.go ../go.mod ../go.sum
+	$(TAR) --transform 's#^#libtailscale/#' --transform 's#Makefile.src#Makefile#' -acf $@ Makefile.src configure ../vendor ../LICENSE ../tailscale.go ../go.mod ../go.sum

--- a/sourcepkg/Makefile.src
+++ b/sourcepkg/Makefile.src
@@ -1,0 +1,43 @@
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+
+prefix?=/usr/local
+libdir?=$(prefix)/lib
+includedir?=$(prefix)/include
+
+all: libtailscale.a libtailscale.so libtailscale.pc
+
+libtailscale.a:
+	go build -trimpath -buildvcs=false -buildmode=c-archive -o libtailscale.a
+
+libtailscale.so:
+	go build -trimpath -buildvcs=false -buildmode=c-shared -o libtailscale.so
+
+# TODO(raggi): the dylib build currently fails to build for amd64 on macOS on an
+# M1, the toolchain reports a build constraints error despite no build
+# constraints.
+libtailscale.dylib:
+	GOARCH=amd64 GOOS=darwin go build -trimpath -buildmode=c-shared -o libtailscale.dylib.amd64 .
+	GOARCH=arm64 GOOS=darwin go build -trimpath -buildmode=c-shared -o libtailscale.dylib.arm64 .
+	lipo -create -output libtailscale.dylib libtailscale.dylib.amd64 libtailscale.dylib.arm64
+
+libtailscale.pc:
+	echo "prefix=/usr/local" > libtailscale.pc
+	echo "exec_prefix=\$${prefix}" >> libtailscale.pc
+	echo "libdir=\$${exec_prefix}/lib" >> libtailscale.pc
+	echo "includedir=\$${prefix}/include" >> libtailscale.pc
+	echo "" >> libtailscale.pc
+	echo "Name: libtailscale" >> libtailscale.pc
+	echo "Description: Tailscale library" >> libtailscale.pc
+	echo "Version: 0.0.1" >> libtailscale.pc
+	echo "Libs: -L\$${libdir} -ltailscale" >> libtailscale.pc
+	echo "Cflags: -I\$${includedir}" >> libtailscale.pc
+
+install: libtailscale.a libtailscale.so libtailscale.pc
+	install -d $(DESTDIR)$(libdir)
+	install -m 644 libtailscale.a $(DESTDIR)$(libdir)
+	install -m 644 libtailscale.so $(DESTDIR)$(libdir)
+	install -d $(DESTDIR)$(libdir)/pkgconfig
+	install -m 644 libtailscale.pc $(DESTDIR)$(libdir)/pkgconfig
+	install -d $(DESTDIR)$(includedir)
+	install -m 644 *.h $(DESTDIR)$(includedir)

--- a/sourcepkg/README.md
+++ b/sourcepkg/README.md
@@ -1,0 +1,5 @@
+# libtailscale - Source package
+
+This directory contains extra code included in the `libtailscale` source
+package. The source package can be built using the `Makefile` in the top level
+project directory.

--- a/sourcepkg/configure
+++ b/sourcepkg/configure
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+
+go version > /dev/null 2>&1 || { echo >&2 "A Go compiler is required."; exit 1; }


### PR DESCRIPTION
If you want to construct a package build for a distribution, you typically need a copy of all of the sources. This produces an archive that has a sufficiently common form that packagers can easily consume.

The final tarball `make install` target installs .h, .so, .a and .pc into $prefix, e.g.

```
% find /usr/local -name libtailscale\*
/usr/local/lib/libtailscale.so
/usr/local/lib/libtailscale.a
/usr/local/lib/pkgconfig/libtailscale.pc
/usr/local/include/libtailscale.h
```

and pkg-config is configured:

```
% pkg-config --static --cflags libtailscale
-I/usr/local/include
% pkg-config --static --libs libtailscale
-L/usr/local/lib -ltailscale
% pkg-config --libs libtailscale
-L/usr/local/lib -ltailscale
```