### PR TITLE
libtailscale: take a C.int, not a Go int

### DIFF
--- a/tailscale.go
+++ b/tailscale.go
@@ -349,7 +349,7 @@ func TsnetSetEphemeral(sd C.int, e int) C.int {
 }
 
 //export TsnetSetLogFD
-func TsnetSetLogFD(sd C.int, fd int) C.int {
+func TsnetSetLogFD(sd, fd C.int) C.int {
 	s, err := getServer(sd)
 	if err != nil {
 		return s.recErr(err)


### PR DESCRIPTION
This was compiling because of the implicit integer conversion on the C side. But -1 was becoming INT32MAX. Which was an invalid fd, so the logs were hidden just as if the fd were -1. But it filled strace with EBADF.