### PR TITLE
Add missing macOS framework in echo_server.c

### DIFF
--- a/example/echo_server.c
+++ b/example/echo_server.c
@@ -14,7 +14,7 @@
 //
 // On macOS you may need to add the following flags to your C compiler:
 //
-// 	-framework CoreFoundation -framework Security
+// 	-framework CoreFoundation -framework Security -framework IOKit
 //
 
 #include "../tailscale.h"


### PR DESCRIPTION
Currently (at least on macOS Sequoia 15.2) the `example/echo_server.c` doesn't build with the following error:

```bash
cc -framework CoreFoundation -framework Security echo_server.c ../libtailscale.a
Undefined symbols for architecture arm64:
  "_IOObjectRelease", referenced from:
      _getSerialNumber in libtailscale.a[17](000014.o)
  "_IORegistryEntryCreateCFProperty", referenced from:
      _getSerialNumber in libtailscale.a[17](000014.o)
  "_IOServiceGetMatchingService", referenced from:
      _getSerialNumber in libtailscale.a[17](000014.o)
  "_IOServiceMatching", referenced from:
      _getSerialNumber in libtailscale.a[17](000014.o)
  "_kIOMainPortDefault", referenced from:
      _getSerialNumber in libtailscale.a[17](000014.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I could trace this problem to missing `-framework IOKit` in the hint about building on macOS.
So to save time for others who might also be trying this example, it would be nice to add it.

---

I couldn't find any contributing guide in this repository, so sorry in advance if I made any mistakes — just let me know, and I'll fix them. :)