### PR TITLE
Add tailscale_enable_funnel_to_localhost_plaintext_http1 to tailscale.h

### DIFF
--- a/tailscale.c
+++ b/tailscale.c
@@ -23,6 +23,7 @@ extern int TsnetGetIps(int sd, char *buf, size_t buflen);
 extern int TsnetGetRemoteAddr(int listener, int conn, char *buf, size_t buflen);
 extern int TsnetListen(int sd, char* net, char* addr, int* listenerOut);
 extern int TsnetLoopback(int sd, char* addrOut, size_t addrLen, char* proxyOut, char* localOut);
+extern int TsnetEnableFunnelToLocalhostPlaintextHttp1(int sd, int localhostPort);
 
 tailscale tailscale_new() {
 	return TsnetNewServer();
@@ -105,4 +106,8 @@ int tailscale_loopback(tailscale sd, char* addr_out, size_t addrlen, char* proxy
 
 int tailscale_errmsg(tailscale sd, char* buf, size_t buflen) {
 	return TsnetErrmsg(sd, buf, buflen);
+}
+
+int tailscale_enable_funnel_to_localhost_plaintext_http1(tailscale sd, int localhostPort) {
+	return TsnetEnableFunnelToLocalhostPlaintextHttp1(sd, localhostPort);
 }

--- a/tailscale.h
+++ b/tailscale.h
@@ -175,6 +175,22 @@ extern int tailscale_accept(tailscale_listener listener, tailscale_conn* conn_ou
 // Returns zero on success or -1 on error, call tailscale_errmsg for details.
 extern int tailscale_loopback(tailscale sd, char* addr_out, size_t addrlen, char* proxy_cred_out, char* local_api_cred_out);
 
+// tailscale_enable_funnel_to_localhost_plaintext_http1 configures sd to have
+// Tailscale Funnel enabled, routing requests from the public web
+// (without any authentication) down to this Tailscale node, requesting new 
+// LetsEncrypt TLS certs as needed, terminating TLS, and proxying all incoming
+// HTTPS requests to http://127.0.0.1:localhostPort without TLS. 
+//
+// There should be a plaintext HTTP/1 server listening on 127.0.0.1:localhostPort
+// or tsnet will serve HTTP 502 errors.
+//
+// Expect junk traffic from the internet from bots watching the public CT logs.
+//
+// Returns:
+// 	0     - success
+// 	-1    - other error, details printed to the tsnet logger
+extern int tailscale_enable_funnel_to_localhost_plaintext_http1(tailscale sd, int localhostPort);
+
 // tailscale_errmsg writes the details of the last error to buf.
 // 
 // After returning, buf is always NUL-terminated.


### PR DESCRIPTION
Adds a way to enable a funnel from libtailscale.  