### PR TITLE
swift: add public modifiers to methods/types that need to be public

### DIFF
--- a/swift/TailscaleKit/Listener.swift
+++ b/swift/TailscaleKit/Listener.swift
@@ -20,9 +20,9 @@ public actor Listener {
     ///
     /// @param tailscale A handle to a Tailscale server
     /// @param proto The ip protocol to listen for
-    /// @param address The adderss (ip:port or port) to listen on
+    /// @param address The address (ip:port or port) to listen on
     /// @param logger An optional LogSink
-    init(tailscale: TailscaleHandle,
+    public init(tailscale: TailscaleHandle,
          proto: NetProtocol,
          address: String,
          logger: LogSink? = nil) async throws {
@@ -68,7 +68,7 @@ public actor Listener {
     ///                value of Int32.max ms and supports millisecond precision per poll(2)
     /// @throws TailscaleError on failure or timeout
     /// @returns An incoming connection from which you can receive() Data
-    func accept(timeout: TimeInterval = 60) async throws -> IncomingConnection {
+    public func accept(timeout: TimeInterval = 60) async throws -> IncomingConnection {
         if timeout * 1000 > Double(Int32.max) || timeout < 0 {
             throw TailscaleError.invalidTimeout
         }

--- a/swift/TailscaleKit/LogSink.swift
+++ b/swift/TailscaleKit/LogSink.swift
@@ -10,7 +10,7 @@ public protocol LogSink: Sendable {
     /// to this.  STDOUT_FILENO or a handle to a writable file.
     var logFileHandle: Int32? { get }
 
-    /// Called for swfit interal logs.
+    /// Called for swift internal logs.
     func log(_ message: String)
 }
 

--- a/swift/TailscaleKit/OutgoingConnection.swift
+++ b/swift/TailscaleKit/OutgoingConnection.swift
@@ -21,9 +21,9 @@ public enum ListenterState {
     case failed         ///< The attempt to start the listener failed
 }
 
-typealias TailscaleHandle = Int32
-typealias TailscaleConnection = Int32
-typealias TailscaleListener = Int32
+public typealias TailscaleHandle = Int32
+public typealias TailscaleConnection = Int32
+public typealias TailscaleListener = Int32
 
 /// Outgoing connections are used to send data to other endpoints
 /// on the tailnet.
@@ -49,7 +49,7 @@ public actor OutgoingConnection {
     /// @param logger
     ///
     /// @throws TailscaleError on failure
-    init(tailscale: TailscaleHandle,
+    public init(tailscale: TailscaleHandle,
          to address: String,
          proto: NetProtocol,
          logger: LogSink) async throws {
@@ -66,7 +66,7 @@ public actor OutgoingConnection {
     /// @See tailscale_dial in Tailscale.h
     ///
     /// @throws TailscaleError on failure
-    func connect() async throws  {
+    public func connect() async throws  {
         let res = tailscale_dial(tailscale, proto.rawValue, address, &conn)
 
         guard res == 0 else {

--- a/swift/TailscaleKit/TailscaleNode.swift
+++ b/swift/TailscaleKit/TailscaleNode.swift
@@ -45,7 +45,7 @@ public actor TailscaleNode {
 
     /// Handle to the underlying Tailscale server.  Use this when instantiating
     /// new IncomingConnections or OutgoingConnections
-    let tailscale: TailscaleHandle?
+    public let tailscale: TailscaleHandle?
 
     private let logger: LogSink?
 

--- a/swift/TailscaleKit/URLSession+Tailscale.swift
+++ b/swift/TailscaleKit/URLSession+Tailscale.swift
@@ -36,7 +36,7 @@ public extension URLSessionConfiguration {
         ]
     }
 
-    public static func tailscaleSession(_ node: TailscaleNode) async throws -> URLSessionConfiguration {
+    static func tailscaleSession(_ node: TailscaleNode) async throws -> URLSessionConfiguration {
         let config = URLSessionConfiguration.default
         try await config.proxyVia(node)
         return config


### PR DESCRIPTION
updates tailscale/tailscale#13937

A few of the initializers and related types on the Listener and {Inbound, Outbound}Connection were default-internal and must be public.  Typos.