### PR TITLE
Add tailscale_status_json for in-memory LocalAPI status

### DIFF
--- a/swift/TailscaleKit/TailscaleKit.h
+++ b/swift/TailscaleKit/TailscaleKit.h
@@ -182,6 +182,22 @@ extern int tailscale_accept(tailscale_listener listener, tailscale_conn* conn_ou
 // Returns zero on success or -1 on error, call tailscale_errmsg for details.
 extern int tailscale_loopback(tailscale sd, char* addr_out, size_t addrlen, char* proxy_cred_out, char* local_api_cred_out);
 
+// tailscale_status_json writes the backend status (the JSON encoding of
+// ipnstate.Status, the same struct LocalAPI's /localapi/v0/status returns)
+// to *json_out as a NUL-terminated, malloc'd string. The caller owns the
+// string and must release it with free().
+//
+// Unlike reading /status over the tailscale_loopback HTTP server, this
+// goes through tsnet's in-memory LocalAPI listener: it keeps working when
+// the OS reclaims the loopback TCP listener from a suspended process
+// (observed on iOS), where the loopback address goes permanently stale.
+//
+// Returns:
+// 	0     - success, *json_out is set
+// 	EBADF - sd is not a valid tailscale
+// 	-1    - call tailscale_errmsg for details (*json_out is NULL)
+extern int tailscale_status_json(tailscale sd, char** json_out);
+
 // tailscale_errmsg writes the details of the last error to buf.
 //
 // After returning, buf is always NUL-terminated.

--- a/swift/TailscaleKit/TailscaleNode.swift
+++ b/swift/TailscaleKit/TailscaleNode.swift
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & AUTHORS
 // SPDX-License-Identifier: BSD-3-Clause
 
+import Foundation
+
 public let kDefaultControlURL = "https://controlplane.tailscale.com"
 
 
@@ -132,6 +134,32 @@ public actor TailscaleNode {
             throw TailscaleError.fromPosixErrCode(res, tailscale.getErrorMessage())
         }
         logger?.log("Brought Tailscale up:\(tailscale)")
+    }
+
+    /// Returns the backend status as the JSON encoding of ipnstate.Status —
+    /// the same document LocalAPI's /localapi/v0/status serves.
+    ///
+    /// Unlike reading /status via loopback()'s HTTP server, this goes through
+    /// tsnet's in-memory LocalAPI listener: it keeps working when the OS
+    /// reclaims the loopback TCP listener from a suspended process (observed
+    /// on iOS), where the cached loopback address goes permanently stale.
+    ///
+    /// @See tailscale_status_json in Tailscale.h
+    ///
+    /// @throws TailscaleError on failure
+    public func statusJSON() async throws -> Data {
+        guard let tailscale else {
+            throw TailscaleError.badInterfaceHandle
+        }
+
+        var out: UnsafeMutablePointer<CChar>?
+        let res = tailscale_status_json(tailscale, &out)
+
+        guard res == 0, let out else {
+            throw TailscaleError.fromPosixErrCode(res, tailscale.getErrorMessage())
+        }
+        defer { free(out) }
+        return Data(bytes: out, count: strlen(out))
     }
 
     /// Tears down the Tailscale server.

--- a/tailscale.c
+++ b/tailscale.c
@@ -24,6 +24,7 @@ extern int TsnetGetRemoteAddr(int listener, int conn, char *buf, size_t buflen);
 extern int TsnetListen(int sd, char* net, char* addr, int* listenerOut);
 extern int TsnetAccept(int ld, int* connOut);
 extern int TsnetLoopback(int sd, char* addrOut, size_t addrLen, char* proxyOut, char* localOut);
+extern int TsnetStatusJSON(int sd, char** jsonOut);
 extern int TsnetEnableFunnelToLocalhostPlaintextHttp1(int sd, int localhostPort);
 
 tailscale tailscale_new() {
@@ -83,6 +84,10 @@ int tailscale_set_logfd(tailscale sd, int fd) {
 
 int tailscale_loopback(tailscale sd, char* addr_out, size_t addrlen, char* proxy_cred_out, char* local_api_cred_out) {
 	return TsnetLoopback(sd, addr_out, addrlen, proxy_cred_out, local_api_cred_out);
+}
+
+int tailscale_status_json(tailscale sd, char** json_out) {
+	return TsnetStatusJSON(sd, json_out);
 }
 
 int tailscale_errmsg(tailscale sd, char* buf, size_t buflen) {

--- a/tailscale.go
+++ b/tailscale.go
@@ -9,6 +9,7 @@ import "C"
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -18,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -578,6 +580,38 @@ func TsnetLoopback(sd C.int, addrOut *C.char, addrLen C.size_t, proxyOut *C.char
 	copy(out, localAPICred)
 	out[32] = '\x00'
 
+	return 0
+}
+
+//export TsnetStatusJSON
+func TsnetStatusJSON(sd C.int, jsonOut **C.char) C.int {
+	if jsonOut == nil {
+		panic("status_json passed nil json_out")
+	}
+	*jsonOut = nil
+	s := getServer(sd)
+	if s == nil {
+		return C.EBADF
+	}
+	// LocalClient rides tsnet's in-memory LocalAPI listener — unlike
+	// Loopback()'s TCP listener it cannot be reclaimed by the OS while
+	// the process is suspended (iOS), so status reads keep working on
+	// long-lived nodes.
+	lc, err := s.s.LocalClient()
+	if err != nil {
+		return s.recErr(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	st, err := lc.Status(ctx)
+	if err != nil {
+		return s.recErr(err)
+	}
+	b, err := json.Marshal(st)
+	if err != nil {
+		return s.recErr(err)
+	}
+	*jsonOut = C.CString(string(b))
 	return 0
 }
 

--- a/tailscale.h
+++ b/tailscale.h
@@ -175,6 +175,22 @@ extern int tailscale_accept(tailscale_listener listener, tailscale_conn* conn_ou
 // Returns zero on success or -1 on error, call tailscale_errmsg for details.
 extern int tailscale_loopback(tailscale sd, char* addr_out, size_t addrlen, char* proxy_cred_out, char* local_api_cred_out);
 
+// tailscale_status_json writes the backend status (the JSON encoding of
+// ipnstate.Status, the same struct LocalAPI's /localapi/v0/status returns)
+// to *json_out as a NUL-terminated, malloc'd string. The caller owns the
+// string and must release it with free().
+//
+// Unlike reading /status over the tailscale_loopback HTTP server, this
+// goes through tsnet's in-memory LocalAPI listener: it keeps working when
+// the OS reclaims the loopback TCP listener from a suspended process
+// (observed on iOS), where the loopback address goes permanently stale.
+//
+// Returns:
+// 	0     - success, *json_out is set
+// 	EBADF - sd is not a valid tailscale
+// 	-1    - call tailscale_errmsg for details (*json_out is NULL)
+extern int tailscale_status_json(tailscale sd, char** json_out);
+
 // tailscale_enable_funnel_to_localhost_plaintext_http1 configures sd to have
 // Tailscale Funnel enabled, routing requests from the public web
 // (without any authentication) down to this Tailscale node, requesting new 


### PR DESCRIPTION
## What

Add `tailscale_status_json(tailscale sd, char** json_out)` (C API) and `TailscaleNode.statusJSON()` (Swift), returning the JSON encoding of `ipnstate.Status` — the same document LocalAPI's `/localapi/v0/status` serves — via tsnet's in-memory LocalAPI listener. The caller owns the returned string and frees it.

## Why

The existing way to read status from an embedded node is over the `tailscale_loopback` HTTP server. On iOS the OS reclaims that loopback TCP listener when the process is suspended, after which the cached loopback address is permanently stale and `/status` is unreachable for the life of the node.

Going through tsnet's in-memory LocalAPI listener keeps working across suspension. The addition is self-contained and additive — no change to existing APIs.

Encountered while building an iOS app that embeds libtailscale and needs backend status (peers, BackendState, etc.) after the process has been backgrounded.

Updates tailscale/tailscale#20060