### PR TITLE
swift: run tailscale_up off the TailscaleNode actor

### DIFF
--- a/swift/TailscaleKit/TailscaleNode.swift
+++ b/swift/TailscaleKit/TailscaleNode.swift
@@ -128,7 +128,9 @@ public actor TailscaleNode {
         }
 
         logger?.log("Bringing Tailscale up :\(tailscale)")
-        let res = tailscale_up(tailscale)
+        // up() is locking pending successful login.  Run in a detached task so we
+        // don't block the actor.
+        let res = await Task.detached { tailscale_up(tailscale) }.value
 
         guard res == 0 else {
             throw TailscaleError.fromPosixErrCode(res, tailscale.getErrorMessage())


### PR DESCRIPTION
> **Revised twice.** The first version of this PR diagnosed the hang as SOCKS5 proxy routing and quoted a "before" figure I had not actually run — both wrong. The second fixed the diagnosis but worked around the stall with a `nonisolated` memoized read. This version takes @barnstar's suggestion instead, which is a better fix, and the measurements below say why.

## Symptom

`LocalAPIClient` is unusable during node bring-up. `startLoginInteractive()`, `backendStatus()` and `watchIPNBus()` all block until `up()` completes — minutes for an interactive login, indefinitely if the user never finishes it. `startLoginInteractive()` is precisely the call you want in that window.

After `up()` returns, every one of these works normally. That is why the failure is easy to misread: measured from the healthy state, nothing is wrong.

## Cause

`up()` ran `tailscale_up` inline on the `TailscaleNode` actor. That C call blocks until the node is usable, so the actor was held for the whole login and every other actor-isolated call queued behind it.

That is broader than `LocalAPIClient`. It also means:

- `statusJSON()` (added in 8077131) is unreachable during login, for the same reason.
- `close()` is unreachable during login — so the cancellation path `tailscale.h` documents ("To cancel an in-progress call to `tailscale_up`, use `tailscale_close`") could not be used from TailscaleKit at all.

## Fix

```swift
let res = await Task.detached { tailscale_up(tailscale) }.value
```

The `await` suspends `up()` and releases the actor, so concurrent calls are serviced. `TailscaleHandle` is `Int32`, so the capture is trivially `Sendable`. One line of behaviour change, plus a regression test.

## Measurements

Same machine, same session, same test, baseline first. macOS arm64, Xcode 26.1.1, Swift 6.2.1. The node points at a control URL that never completes registration, so it stays in `NeedsLogin` and `up()` is genuinely in flight for the whole measurement — the state the defect lives in.

| Build | `loopback()` called while `up()` is in flight |
|---|---|
| stock (`main`) | **HUNG** — no return within 10007 ms |
| this PR | **returned in 22 ms**, addr `127.0.0.1:52042` |

Both runs assert that `up()` had not returned, before and after, so neither samples the healthy state.

**Why releasing the actor is sufficient on its own.** The Go layer never serialised these: `tsnet.Server.Up()` blocks on an IPN bus watcher rather than a lock, and `Loopback()` only takes the brief `servers` map lock. Measured directly against tsnet with `testcontrol{RequireAuth: true}`, so `Up()` was stuck in `NeedsLogin`:

```
MEASURED: Up() still blocked after 3.001599667s
MEASURED: Loopback() returned in 433.584µs addr=127.0.0.1:51590 proxyCredLen=32 localCredLen=32
MEASURED: Up() confirmed still blocked at end of measurement
```

This is what makes your suggestion strictly better than the `nonisolated` memoized read I had proposed. That version only worked when the loopback config had already been resolved before `up()` was called, and it needed a caveat telling callers to do so. Freeing the actor needs no such caveat: the first `loopback()` call of a node's life now succeeds during login.

## Notes

- `loopback()` stays actor-isolated on purpose. tsnet's `Loopback()` lazily initialises `s.loopbackListener` with no mutex, so the actor's serialisation is load-bearing for concurrent Swift callers.
- `Task.detached` parks a cooperative-pool thread for the duration of the login. That is the tradeoff of a blocking C call; if you would rather not hold a pool thread for minutes, the same effect is available via a `withCheckedContinuation` over a dedicated `DispatchQueue`. Happy to switch — I went with your version as written.
- The full existing suite (`testV4`, `testV6`, `testProxy`, `testStatus`) passes with this change.

Tracking issue: tailscale/tailscale#20997
Related: #57, from the same work.
