### PR TITLE
build: produce a universal (arm64 + x86_64) macOS slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,16 @@ libtailscale_ios_sim_arm64.a:
 libtailscale_ios_sim_x86_64.a:
 	GOOS=ios GOARCH=amd64 CC=$(PWD)/swift/script/clangwrap-ios-sim-x86.sh go build -v -ldflags -w -tags ios -o $@ -buildmode=c-archive
 
+libtailscale_macos_arm64.a:
+	GOOS=darwin GOARCH=arm64 CC=$(PWD)/swift/script/clangwrap-macos-arm.sh $(DARWIN_DEPLOYMENT_TARGET) go build -v -ldflags -w -o $@ -buildmode=c-archive
+
+libtailscale_macos_x86_64.a:
+	GOOS=darwin GOARCH=amd64 CC=$(PWD)/swift/script/clangwrap-macos-x86.sh $(DARWIN_DEPLOYMENT_TARGET) go build -v -ldflags -w -o $@ -buildmode=c-archive
+
+.PHONY: c-archive-macos-universal
+c-archive-macos-universal: libtailscale_macos_arm64.a libtailscale_macos_x86_64.a ## Builds a universal (arm64 + x86_64) libtailscale.a for macOS
+	lipo -create -output libtailscale.a libtailscale_macos_arm64.a libtailscale_macos_x86_64.a
+
 .PHONY: c-archive-ios
 c-archive-ios: libtailscale_ios.a  ## Builds libtailscale_ios.a for iOS (iOS SDK required)
 

--- a/swift/Makefile
+++ b/swift/Makefile
@@ -17,12 +17,13 @@ all: test ios macos ios-fat  ## Runs the tests and builds all library targets
 macos:  ## Builds TailscaleKit for macos to swift/build/Build/Products/Release (unsigned)
 	@echo
 	@echo "::: Building TailscaleKit.framework for macOS :::"
-	cd .. && make c-archive
+	cd .. && make c-archive-macos-universal
 	mkdir -p build
 	xcodebuild build -scheme "TailscaleKit (macOS)" \
 	 -derivedDataPath build \
 	 -configuration Release \
-	 -destination 'platform=macOS,arch=arm64' \
+	 -destination 'generic/platform=macOS' \
+	 ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
 	 CODE_SIGNING_ALLOWED=NO | $(XCPRETTIFIER)
 
 .PHONY: ios

--- a/swift/script/clangwrap-macos-arm.sh
+++ b/swift/script/clangwrap-macos-arm.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+SDK=macosx
+CLANGARCH=arm64
+
+SDK_PATH=`xcrun --sdk $SDK --show-sdk-path`
+
+# cmd/cgo doesn't support llvm-gcc-4.2, so we have to use clang.
+CLANG=`xcrun --sdk $SDK --find clang`
+
+exec "$CLANG" -arch $CLANGARCH -isysroot "$SDK_PATH" -mmacos-version-min=15.0 "$@"

--- a/swift/script/clangwrap-macos-x86.sh
+++ b/swift/script/clangwrap-macos-x86.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+SDK=macosx
+CLANGARCH=x86_64
+
+SDK_PATH=`xcrun --sdk $SDK --show-sdk-path`
+
+# cmd/cgo doesn't support llvm-gcc-4.2, so we have to use clang.
+CLANG=`xcrun --sdk $SDK --find clang`
+
+exec "$CLANG" -arch $CLANGARCH -isysroot "$SDK_PATH" -mmacos-version-min=15.0 "$@"


### PR DESCRIPTION
## Problem

The macOS build is Apple-Silicon-only by construction, so an app embedding `TailscaleKit` can't produce a universal macOS release build:

```
TailscaleKit.xcframework is missing architecture(s) required by this target
(x86_64), but may still be link-compatible
```

Two places pin it:

| Where | What |
|---|---|
| root `Makefile` — `c-archive` | builds `libtailscale.a` for the **host** arch; no `GOARCH` is set |
| `swift/Makefile` — `macos` | `-destination 'platform=macOS,arch=arm64'`, so the framework is one arch even if the archive were fat |

## Approach

The iOS Simulator target already solves exactly this — separate `GOARCH=arm64` and `GOARCH=amd64` c-archives joined with `lipo`, each built through a clangwrap script pinning SDK and arch. This mirrors that pattern rather than inventing a second one:

- `clangwrap-macos-arm.sh` / `clangwrap-macos-x86.sh`, matching the existing `ios-sim` wrappers and pinning `-mmacos-version-min` to `MACOS_TARGET` (15.0)
- `libtailscale_macos_arm64.a` and `libtailscale_macos_x86_64.a`
- `c-archive-macos-universal`, which `lipo`s them into `libtailscale.a`
- `swift/Makefile`'s `macos` target uses it, and builds with `-destination 'generic/platform=macOS' ARCHS="arm64 x86_64"`

**`make c-archive` is untouched**, so anything building for the host only keeps its current behaviour.

## Verified

On an Apple Silicon host:

```
$ lipo -info libtailscale.a
Architectures in the fat file: libtailscale.a are: x86_64 arm64

$ make -C swift macos
$ lipo -info swift/build/.../TailscaleKit.framework/Versions/A/TailscaleKit
Architectures in the fat file: ... are: x86_64 arm64
```

Both the archive and the built framework come out universal.

## Scope

4 files, +13 −2, two of them new scripts. No existing target changes behaviour.

Updates tailscale/tailscale#20992

Related: #57 (privacy manifests, macOS slice, upload validator) and #58 (LocalAPI actor deadlock), from the same work.