### PR TITLE
build: let the environment override MACOS_TARGET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,13 @@ export CGO_ENABLED=1
 # This should match the minimum target in the xCode project
 # The wrapper lib currently requires features available in
 # MacOS 15.0 (Sequoia)
-MACOS_TARGET := 15.0
+#
+# `?=` rather than `:=` so the environment can override it. With `:=`,
+# `MACOS_TARGET=14.0 make c-archive` is silently ignored — make reports success
+# and builds 15.0 anyway, because an environment variable does not override a
+# makefile assignment. Only `make MACOS_TARGET=14.0 c-archive` worked, which is
+# easy to get wrong and gives no signal when you do.
+MACOS_TARGET ?= 15.0
 
 # Set macOS-specific flags for darwin builds
 ifeq ($(GOOS),darwin)


### PR DESCRIPTION
`MACOS_TARGET := 15.0` is a simply-expanded assignment, so an **environment variable does not override it**. `MACOS_TARGET=14.0 make c-archive` builds 15.0 and reports success — you set the floor, make agrees, and you get the old one. Only `make MACOS_TARGET=14.0 c-archive` works.

## Measured

`make -n`, `GOOS=darwin`, against this Makefile:

| | before | after |
|---|---|---|
| `MACOS_TARGET=14.0 make …` (env) | **15.0** | 14.0 |
| `make MACOS_TARGET=14.0 …` (command line) | 14.0 | 14.0 |
| default, nothing set | 15.0 | 15.0 |

`?=` fixes the environment case and changes nothing else: a command-line override still wins, and the default is untouched for anyone not setting it.

## Why it's worth fixing

The failure is quiet in a way that matters for this particular variable. Nothing warns, the build succeeds, and the resulting binary is stamped with a floor its Go objects don't actually support. On macOS the only signal is an `ld: warning: object file … was built for newer 'macOS' version`, which is easy to lose in build output — and `otool` won't catch it either, since it reports the number the binary *claims*.

Found while lowering the macOS floor of a `TailscaleKit.xcframework` built from this repo.

It's also the same knob #60's "Aside" points at: if the project lowers its own deployment targets, whoever does that is likely to reach for the environment variable first.

## Not touched here

The comment above the line still says the wrapper requires macOS 15.0 features. That's a separate question and depends on #60, which measures macOS 14.0 as buildable once the listener API is gated — happy to follow up there if that lands.