### PR TITLE
swift: let watchIPNBus outlive a quiet tailnet

### DIFF
--- a/swift/TailscaleKit/LocalAPI/LocalAPIClient.swift
+++ b/swift/TailscaleKit/LocalAPI/LocalAPIClient.swift
@@ -46,6 +46,12 @@ public actor LocalAPIClient {
         self.logger = logger
     }
 
+    /// Pass as `watchIPNBus(timeoutInterval:)` to keep a long poll open across an idle tailnet.
+    /// URLSession has no sentinel for "never": a non-finite timeoutIntervalForRequest is not
+    /// honoured, and a non-positive one restores the 60s default.  So this is simply a span no
+    /// watch will reach.
+    public static let noTimeout: TimeInterval = 365 * 24 * 60 * 60
+
 
     // MARK: - IPN Bus
 
@@ -60,13 +66,31 @@ public actor LocalAPIClient {
     /// - Parameters:
     ///   - mask: a mask indicating the events we wish to observe
     ///   - consumer: an actor implementing MessageConsumer to which incoming events will be sent
+    ///   - timeoutInterval: how long the poll may go WITHOUT receiving data before URLSession fails it
+    ///                      with NSURLErrorTimedOut.  This is not a budget for the whole watch — the
+    ///                      timer restarts on every byte.  Defaults to `noTimeout`, because a watch
+    ///                      should outlive a quiet tailnet; pass a finite value to have the consumer's
+    ///                      error callback run on a schedule instead.
     /// - Returns: The MessageProcessor handling the incoming event stream.  This should be destroyed/stopped when the caller
     ///            wishes to unsubscribe from the event stream.
-    public func watchIPNBus(mask: Ipn.NotifyWatchOpt, consumer: MessageConsumer) async throws -> MessageProcessor {
+    public func watchIPNBus(mask: Ipn.NotifyWatchOpt,
+                            consumer: MessageConsumer,
+                            timeoutInterval: TimeInterval = LocalAPIClient.noTimeout) async throws -> MessageProcessor {
         let params = [URLQueryItem(name: "mask", value: String(mask.rawValue))]
-        let (request, sessionConfig) = try await self.basicAuthURLRequest(endpoint: .watchIPNBus,
-                                                                          method: .GET,
-                                                                          params: params)
+        var request: URLRequest
+        let sessionConfig: URLSessionConfiguration
+        (request, sessionConfig) = try await self.basicAuthURLRequest(endpoint: .watchIPNBus,
+                                                                      method: .GET,
+                                                                      params: params)
+
+        // basicAuthURLRequest hands back URLSessionConfiguration.default, whose
+        // timeoutIntervalForRequest is 60s measured from the LAST byte received.  The bus sends
+        // nothing while the tailnet is idle, so leaving that default in place fails a quiet watch
+        // with -1001 about once a minute, forever.  doSimpleAPIRequest and doJSONAPIRequest below
+        // already take a timeoutInterval and set it on the request; the long poll — the one
+        // endpoint that genuinely needs to outlast its own silence — is the one that never did.
+        request.timeoutInterval = timeoutInterval
+        sessionConfig.timeoutIntervalForRequest = timeoutInterval
 
         let messageProcessor = await MessageProcessor(consumer: consumer, logger: logger)
         messageProcessor.start(request, config: sessionConfig)

--- a/swift/TailscaleKitXCTests/TailscaleKitTests.swift
+++ b/swift/TailscaleKitXCTests/TailscaleKitTests.swift
@@ -182,6 +182,51 @@ final class TailscaleKitTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+
+    /// The bus watch's request timeout is the interval it may go WITHOUT data, not a budget for
+    /// the whole watch, so the default has to outlive an idle tailnet.  Asking for a short one
+    /// pins the plumbing: the timeout has to reach the request that MessageReader actually runs,
+    /// and land on the consumer as NSURLErrorTimedOut.  A test for the DEFAULT would have to
+    /// outsit 60s of silence, which is why the regression went unnoticed.
+    func testWatchIPNBusHonoursItsTimeoutInterval() async throws {
+        let config = mockConfig()
+        let logger = BlackholeLogger()
+
+        let ts1 = try TailscaleNode(config: config, logger: logger)
+        try await ts1.up()
+
+        let timedOut = expectation(description: "the bus watch timed out")
+        let consumer = TimeoutObservingConsumer {
+            let err = $0 as NSError
+            if err.domain == NSURLErrorDomain && err.code == NSURLErrorTimedOut {
+                timedOut.fulfill()
+            }
+        }
+
+        let api = LocalAPIClient(localNode: ts1, logger: logger)
+        let processor = try await api.watchIPNBus(mask: [.initialState, .noPrivateKeys],
+                                                  consumer: consumer,
+                                                  timeoutInterval: 2)
+
+        await fulfillment(of: [timedOut], timeout: 20.0)
+        processor.cancel()
+    }
+}
+
+/// Watches only for the bus's error callback.  The notifications themselves are beside the
+/// point here: the initial state lands immediately, and the test is about the silence after it.
+actor TimeoutObservingConsumer: MessageConsumer {
+    private let onError: @Sendable (any Error) -> Void
+
+    init(onError: @escaping @Sendable (any Error) -> Void) {
+        self.onError = onError
+    }
+
+    func notify(_ notify: Ipn.Notify) {}
+
+    func error(_ error: any Error) {
+        onError(error)
+    }
 }
 
 


### PR DESCRIPTION
Updates tailscale/tailscale#21220

`watchIPNBus` opens a long poll, but builds its request through `basicAuthURLRequest`, which returns `URLSessionConfiguration.default`. That config's `timeoutIntervalForRequest` is 60s, and it is measured from the **last byte received** rather than from the start of the request — so a watch over an idle tailnet is failed with `NSURLErrorTimedOut` roughly once a minute, forever. The consumer sees an error, re-arms, and the cycle repeats.

`doSimpleAPIRequest` and `doJSONAPIRequest` already take `timeoutInterval: TimeInterval = 60` and set it on the request. The long poll — the one endpoint that genuinely has to outlast its own silence — is the one that never got the parameter. This adds it, defaulting to `LocalAPIClient.noTimeout` so the behaviour this method's own doc comment describes ("a single application-wide watcher with the full set of opts will often suffice") is what you actually get.

There is an interaction worth calling out: the doc comment recommends always passing `rateLimitNetmaps`, whose whole job is to make the stream quieter. Following that advice makes the timeout *more* likely to fire.

### Measurements

Found on an iOS 27 device build against a real tailnet, by watching the loopback connection in the OS log. Every watch closed exactly 60s after its last byte:

| mask | duration | bytes in | packets |
|---|---|---|---|
| 282 (`initialState`+`netmap`+`rateLimitNetmaps`+`noPrivateKeys`) | 78.34s | 23,884 | 12 |
| 274 (same, minus the initial netmap) | 60.08s | 606 | 7 |
| 274 | 60.07s | 606 | 7 |

The two shapes are the same bug: 78.3s is ~18s of initial-netmap burst plus the 60s idle timer; 60.08s is the idle timer alone with no burst left to delay it.

With this patch and no other change, the same app over a four-minute soak produced **one watch and zero timeouts**.

### Notes on the choice of sentinel

URLSession has no documented "never" value: a non-finite `timeoutIntervalForRequest` is not honoured, and a non-positive one restores the 60s default. So `noTimeout` is simply a year — a span no watch will reach. Both the request and the session config are set, since `URLRequest.timeoutInterval` overrides the session's for that task. Happy to switch to a different sentinel or drop the public constant if you'd rather it were a plain literal.

### Test

`testWatchIPNBusHonoursItsTimeoutInterval` asks for a 2s timeout and asserts `NSURLErrorTimedOut` reaches the consumer, which pins the plumbing end to end — the value has to survive `basicAuthURLRequest`, `MessageProcessor.start` and the `URLSession` that `MessageReader` actually builds. It runs in ~2.3s.

It deliberately does *not* exercise the default, because doing so would mean outsitting 60s of silence in CI — which is exactly why the missing timeout went unnoticed. Reverting `LocalAPIClient.swift` alone fails the build with `extra argument 'timeoutInterval' in call`.

Full suite locally (`cd swift && make test`), Xcode 27 / Swift 6.4 on macOS arm64:

```
Test case 'TailscaleKitTests.testProxy()' passed (0.583 seconds)
Test case 'TailscaleKitTests.testStatus()' passed (0.530 seconds)
Test case 'TailscaleKitTests.testV4()' passed (0.949 seconds)
Test case 'TailscaleKitTests.testV6()' passed (0.846 seconds)
Test case 'TailscaleKitTests.testWatchIPNBusHonoursItsTimeoutInterval()' passed (2.343 seconds)
```

Unrelated, but in case it bites CI later: the tree does not build under Go 1.27 — `go-json-experiment/json` aliases an `encoding/json/v2` API that moved, giving `undefined: json.SkipFunc`. `GOEXPERIMENT=nojsonv2` works around it; CI's Go 1.24 pin never sees it.